### PR TITLE
Python two and three side by side

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,13 +24,19 @@ The post-mortem function, ``ipdb.pm()``, is equivalent to the magic function
 .. _IPython: http://ipython.org
 
 If you install ``ipdb`` with a tool which supports ``setuptools`` entry points,
-an ``ipdb`` script is made for you. You can use it to debug your scripts like
+an ``ipdb`` script is made for you. You can use it to debug your python3 scripts like
+
+::
+
+        $ bin/ipdb3 mymodule.py
+
+And for python2
 
 ::
 
         $ bin/ipdb mymodule.py
 
-With Python 2.7 only, you can also use
+Alternatively with Python 2.7 only, you can also use
 
 ::
 

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,18 @@
 # for more details.
 
 from setuptools import setup, find_packages
+from sys import version_info
 
 version = '0.7.1dev'
 
 long_description = (open('README.rst').read() +
     '\n\n' + open('HISTORY.txt').read())
+
+
+if version_info.major == 2:
+    console_script = 'ipdb'
+else:
+    console_script = 'ipdb%d' % version_info.major
 
 
 setup(name='ipdb',
@@ -47,7 +54,7 @@ setup(name='ipdb',
           'ipython >= 0.10',
       ],
       entry_points={
-          'console_scripts': ['ipdb = ipdb.__main__:main']
+          'console_scripts': ['%s = ipdb.__main__:main' % console_script]
       },
       use_2to3=True,
 )


### PR DESCRIPTION
When installing ipdb for both python2 and python3 you currently get a conflict with /usr/bin/ipdb.
