### PR TITLE
Newer IPython compability

### DIFF
--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -44,6 +44,8 @@ if IPython.__version__ > '0.10.2':
                 count -= 1
                 if count == 0:
                     raise
+            else:
+                break
 
         ipshell = InteractiveShellEmbed()
         def_colors = ipshell.colors


### PR DESCRIPTION
Hi,

This patch makes ipdb more resilient to different versions of IPython as embed module was moved from **IPython.frontend.terminal.embed** to **IPython.terminal.embed** in latest IPython versions. I believe ipdb in pip is taken from your repository, so would be great to have this fix there.

Cheers,

Piotr
