### PR TITLE
Index into version_info in setup.py for Python 2.6 compatibility.

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 0.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Index into version_info in setup.py for Python 2.6 compatibility.
 
 
 0.7 (2012-07-06)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ long_description = (open('README.rst').read() +
     '\n\n' + open('HISTORY.txt').read())
 
 
-if version_info.major == 2:
+if version_info[0] == 2:
     console_script = 'ipdb'
 else:
     console_script = 'ipdb%d' % version_info.major


### PR DESCRIPTION
Fixes a

```
AttributeError: 'tuple' object has no attribute 'major'
```

in `setup.py` line 23.
