### PR TITLE
Disable IPython history in the debugger, fixing "ProgrammingError: SQLit...

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 0.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Disable IPython history in the debugger, fixing "ProgrammingError: SQLite
+  objects created in a thread can only be used in that same thread."
+  [sunew]
 
 
 0.8 (2013-09-19)
@@ -61,7 +63,7 @@ Changelog
 ----------------
 
 - Add setuptools ``console_scripts`` entry point.
-  [akrito, gotcha] 
+  [akrito, gotcha]
 
 - Nose support.
   Closes https://github.com/gotcha/ipdb/issues/8
@@ -82,12 +84,12 @@ Changelog
   Closes https://github.com/gotcha/ipdb/issues/1
   [gotcha]
 
-- Fixed errors when exiting with "q". 
+- Fixed errors when exiting with "q".
   [gotcha]
 
 - Allow use of ``python -m ipdb mymodule.py``.
-  Python 2.7 only. 
-  Closes https://github.com/gotcha/ipdb/issues/3 
+  Python 2.7 only.
+  Closes https://github.com/gotcha/ipdb/issues/3
   [gotcha]
 
 - Fixed post_mortem when the traceback is None.

--- a/ipdb/__init__.py
+++ b/ipdb/__init__.py
@@ -1,24 +1,26 @@
 # Copyright (c) 2007, 2010, 2011, 2012 Godefroid Chapelle
-# 
+#
 # This file is part of ipdb.
 # GNU package is free software: you can redistribute it and/or modify it under
-# the terms of the GNU General Public License as published by the Free 
-# Software Foundation, either version 2 of the License, or (at your option) 
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 2 of the License, or (at your option)
 # any later version.
 #
-# GNU package is distributed in the hope that it will be useful, but 
+# GNU package is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
 # or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
 # for more details.
 
 # You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
 
+import patches
 from ipdb.__main__ import set_trace, post_mortem, pm, run, runcall, runeval, launch_ipdb_on_exception
 
-pm                       # please pyflakes
-post_mortem              # please pyflakes
-run                      # please pyflakes
-runcall                  # please pyflakes
-runeval                  # please pyflakes
-set_trace                # please pyflakes
-launch_ipdb_on_exception # please pyflakes
+pm                        # please pyflakes
+post_mortem               # please pyflakes
+run                       # please pyflakes
+runcall                   # please pyflakes
+runeval                   # please pyflakes
+set_trace                 # please pyflakes
+launch_ipdb_on_exception  # please pyflakes
+patches                   # please pyflakes

--- a/ipdb/patches.py
+++ b/ipdb/patches.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2007, 2010, 2011, 2012 Godefroid Chapelle
+#
+# This file is part of ipdb.
+# GNU package is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 2 of the License, or (at your option)
+# any later version.
+#
+# GNU package is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+
+# You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
+
+# Disable IPython history in the debugger:
+# The sqlite-based history of newer IPython versions gets
+# confused by multithreaded apps like Zope (and Django?),
+# causing errors when quitting/reloading:
+# "ProgrammingError: SQLite objects created in a thread can only be used in
+# that same thread."
+#
+# It is possible to disable the history in the IPython global configuration
+# file, but the IPython debugger does not load the configuration.
+# When embedding IPython, it is up to each app doing the embedding to configure
+# IPython as needed. But no such possibility exists for the debugger, therefore
+# this patch.
+
+try:
+    from IPython.core.history import HistoryManager
+    HistoryManager.enabled = False
+except ImportError:
+    pass


### PR DESCRIPTION
...e objects created in a thread can only be used in that same thread."

I assume that we can live without the history in the debugger. In multithreaded apps it does not work anyway:)
