### PR TITLE
Don't pass sys.argv to IPython for configuration

### DIFF
--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -63,7 +63,7 @@ if parse_version(IPython.__version__) > parse_version('0.10.2'):
         ipapp = TerminalIPythonApp()
         # Avoid output (banner, prints)
         ipapp.interact = False
-        ipapp.initialize()
+        ipapp.initialize([])
         def_colors = ipapp.shell.colors
     else:
         # If an instance of IPython is already running try to get an instance


### PR DESCRIPTION
TerminalIPythonApp.initialize chokes on sys.argv if the process isn't an IPython shell.