### PR TITLE
Stop trying to magically guess when stdout needs to be captured.

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,12 @@ Changelog
 0.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Stop trying to magically guess when stdout needs to be captured.
+  Like needed by `nose`.
+  Rather, provide a set of function that can be called explicitely when needed.
+  [gotcha]
+
+- drop support of IPython before 0.10.2
 
 
 0.9.0 (2016-02-22)

--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,8 @@ You can also enclose code with the ``with`` statement to launch ipdb if an excep
    Using ``from future import print_function`` for Python 3 compat implies dropping Python 2.5 support.
    Use ``ipdb<=0.8`` with 2.5.
 
-Issues with sdout
------------------
+Issues with `stdout`
+--------------------
 
 Some tools, like `nose` fiddle with `stdout`.
 

--- a/README.rst
+++ b/README.rst
@@ -65,17 +65,17 @@ You can also enclose code with the ``with`` statement to launch ipdb if an excep
    Using ``from future import print_function`` for Python 3 compat implies dropping Python 2.5 support.
    Use ``ipdb<=0.8`` with 2.5.
 
-Issues with `stdout`
---------------------
+Issues with ``stdout``
+----------------------
 
-Some tools, like `nose` fiddle with `stdout`.
+Some tools, like ``nose`` fiddle with ``stdout``.
 
-Until `ipdb==0.9.0`, we tried to guess when we should also
-fiddle with `stdout` to support those tools.
+Until ``ipdb==0.9.0``, we tried to guess when we should also
+fiddle with ``stdout`` to support those tools.
 However, all strategies tried until 0.9.0 have proven brittle.
 
-If you use `nose` or another tool that fiddles with `stdout`, you should
-explicitely ask for `stdout` fiddling by using `ipdb` like this
+If you use ``nose`` or another tool that fiddles with ``stdout``, you should
+explicitely ask for ``stdout`` fiddling by using ``ipdb`` like this
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -80,11 +80,11 @@ explicitely ask for ``stdout`` fiddling by using ``ipdb`` like this
 ::
 
         import ipdb
-        ipdb.s_set_trace()
-        ipdb.s_pm()
+        ipdb.sset_trace()
+        ipdb.spm()
 
-        from ipdb import s_launch_ipdb_on_exception
-        with s_launch_ipdb_on_exception():
+        from ipdb import slaunch_ipdb_on_exception
+        with slaunch_ipdb_on_exception():
             [...]
 
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ IPython `pdb`
 Use
 ---
 
-ipdb exports functions to access the IPython_ debugger, which features 
+ipdb exports functions to access the IPython_ debugger, which features
 tab completion, syntax highlighting, better tracebacks, better introspection
 with the same interface as the `pdb` module.
 
@@ -23,7 +23,7 @@ Example usage:
         result = ipdb.runcall(function, arg0, arg1, kwarg='foo')
         result = ipdb.runeval('f(1,2) - 3')
 
-The post-mortem function, ``ipdb.pm()``, is equivalent to the magic function 
+The post-mortem function, ``ipdb.pm()``, is equivalent to the magic function
 ``%debug``.
 
 .. _IPython: http://ipython.org
@@ -65,6 +65,29 @@ You can also enclose code with the ``with`` statement to launch ipdb if an excep
    Using ``from future import print_function`` for Python 3 compat implies dropping Python 2.5 support.
    Use ``ipdb<=0.8`` with 2.5.
 
+Issues with sdout
+-----------------
+
+Some tools, like `nose` fiddle with `stdout`.
+
+Until `ipdb==0.9.0`, we tried to guess when we should also
+fiddle with `stdout` to support those tools.
+However, all strategies tried until 0.9.0 have proven brittle.
+
+If you use `nose` or another tool that fiddles with `stdout`, you should
+explicitely ask for `stdout` fiddling by using `ipdb` like this
+
+::
+
+        import ipdb
+        ipdb.s_set_trace()
+        ipdb.s_pm()
+
+        from ipdb import s_launch_ipdb_on_exception
+        with s_launch_ipdb_on_exception():
+            [...]
+
+
 Development
 -----------
 
@@ -78,7 +101,7 @@ Third-party support
 Products.PDBDebugMode
 +++++++++++++++++++++
 
-Zope2 Products.PDBDebugMode_ uses ``ipdb``, if available, in place of ``pdb``. 
+Zope2 Products.PDBDebugMode_ uses ``ipdb``, if available, in place of ``pdb``.
 
 .. _Products.PDBDebugMode: http://pypi.python.org/pypi/Products.PDBDebugMode
 

--- a/ipdb/__init__.py
+++ b/ipdb/__init__.py
@@ -13,3 +13,10 @@ runcall                  # please pyflakes
 runeval                  # please pyflakes
 set_trace                # please pyflakes
 launch_ipdb_on_exception # please pyflakes
+
+from ipdb.stdout import sset_trace, spost_mortem, spm, slaunch_ipdb_on_exception
+
+spm                       # please pyflakes
+spost_mortem              # please pyflakes
+sset_trace                # please pyflakes
+slaunch_ipdb_on_exception # please pyflakes

--- a/ipdb/stdout.py
+++ b/ipdb/stdout.py
@@ -1,0 +1,37 @@
+from __future__ import print_function
+import sys
+from contextlib import contextmanager
+from IPython.utils import io
+from __main__ import set_trace
+from __main__ import post_mortem
+
+
+def update_stdout():
+    # setup stdout to ensure output is available with nose
+    io.stdout = sys.stdout = sys.__stdout__
+
+
+def sset_trace(frame=None, context=3):
+    update_stdout()
+    set_trace(frame, context)
+
+
+def spost_mortem(tb):
+    update_stdout()
+    post_mortem(tb)
+
+
+def spm():
+    spost_mortem(sys.last_traceback)
+
+
+@contextmanager
+def slaunch_ipdb_on_exception():
+    try:
+        yield
+    except Exception:
+        e, m, tb = sys.exc_info()
+        print(m.__repr__(), file=sys.stderr)
+        spost_mortem(tb)
+    finally:
+        pass

--- a/ipdb/stdout.py
+++ b/ipdb/stdout.py
@@ -13,6 +13,8 @@ def update_stdout():
 
 def sset_trace(frame=None, context=3):
     update_stdout()
+    if frame is None:
+        frame = sys._getframe().f_back
     set_trace(frame, context)
 
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(name='ipdb',
       zip_safe=True,
       test_suite='tests',
       install_requires=[
-          'ipython >= 0.10',
+          'ipython >= 0.10.2',
           'setuptools'
       ],
       entry_points={


### PR DESCRIPTION
Like needed by `nose`.
Rather, provide a set of functions that can be called explicitely when needed.

drop support of IPython before 0.10.2