### PR TITLE
Fix import failure on older ipython versions

### DIFF
--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -11,7 +11,6 @@ import sys
 import traceback
 from pkg_resources import parse_version
 
-from IPython.terminal.ipapp import load_default_config
 from contextlib import contextmanager
 
 try:


### PR DESCRIPTION
The removed import was unused anyway.