### PR TITLE
Don't require users to pass a traceback to post_mortem

### DIFF
--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -133,14 +133,18 @@ def set_trace(frame=None, context=3):
     p.shell.restore_sys_module_state()
 
 
-def post_mortem(tb):
+def post_mortem(tb=None):
     update_stdout()
     wrap_sys_excepthook()
     p = _init_pdb()
     p.reset()
     if tb is None:
-        return
-    p.interaction(None, tb)
+        # sys.exc_info() returns (type, value, traceback) if an exception is
+        # being handled, otherwise it returns None
+        tb = sys.exc_info()[2]
+
+    if tb:
+        p.interaction(None, tb)
 
 
 def pm():


### PR DESCRIPTION
This parameter is optional in pdb:
https://docs.python.org/3.5/library/pdb.html#pdb.post_mortem
so ipdb should provide the same API.