### PR TITLE
Fix context size setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,6 @@
 IPython `pdb`
 =============
 
-(fork repo with fixed context and context receiving from env variable)
----
-
 .. image:: https://travis-ci.org/gotcha/ipdb.png?branch=master
   :target: https://travis-ci.org/gotcha/ipdb
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,5 @@
 IPython `pdb`
+(fork repo with fixed context and context receiving from env variable)
 =============
 
 .. image:: https://travis-ci.org/gotcha/ipdb.png?branch=master

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ Example usage:
         ipdb.set_trace()
         ipdb.set_trace(context=5)  # will show five lines of code
                                    # instead of the default three lines
+                                   # Or you can set it using IPDB_CONTEXT_SIZE env variable.
         ipdb.pm()
         ipdb.run('x[0] = 3')
         result = ipdb.runcall(function, arg0, arg1, kwarg='foo')

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 IPython `pdb`
-(fork repo with fixed context and context receiving from env variable)
 =============
+
+(fork repo with fixed context and context receiving from env variable)
+---
 
 .. image:: https://travis-ci.org/gotcha/ipdb.png?branch=master
   :target: https://travis-ci.org/gotcha/ipdb

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -87,6 +87,12 @@ def wrap_sys_excepthook():
 
 
 def set_trace(frame=None, context=3):
+    try:
+        # Try to get and redeclare env variable with value of context
+        context = os.environ['IPDB_CONTEXT_SIZE']
+    except KeyError:
+        pass
+
     wrap_sys_excepthook()
     if frame is None:
         frame = sys._getframe().f_back

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -88,7 +88,7 @@ def wrap_sys_excepthook():
 
 def set_trace(frame=None, context=3):
     try:
-        # Try to get and redeclare env variable with value of context
+        # Try to get and redeclare context with value of env variabe
         context = os.environ['IPDB_CONTEXT_SIZE']
     except KeyError:
         pass

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -86,12 +86,13 @@ def wrap_sys_excepthook():
         sys.excepthook = BdbQuit_excepthook
 
 
-def set_trace(frame=None, context=3):
-    try:
-        # Try to get and redeclare context with value of env variabe
-        context = os.environ['IPDB_CONTEXT_SIZE']
-    except KeyError:
+def set_trace(frame=None, context=None):
+    if context:
         pass
+    elif os.getenv('IPDB_CONTEXT_SIZE'):
+        context = int(os.environ['IPDB_CONTEXT_SIZE'])
+    else:
+        context = 3
 
     wrap_sys_excepthook()
     if frame is None:

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -24,11 +24,11 @@ def import_module(possible_modules, needed_module):
             if count == 0:
                 raise
 try:
-    from IPython.core.debugger import Pdb, BdbQuit_excepthook
-except ImportError:
     # For some versions of IPython 5.x
     from IPython.terminal.debugger import TerminalPdb as Pdb
     from IPython.core.debugger import BdbQuit_excepthook
+except ImportError:
+    from IPython.core.debugger import Pdb, BdbQuit_excepthook
 
 possible_modules = ['IPython.terminal.ipapp',           # Newer IPython
                     'IPython.frontend.terminal.ipapp']  # Older IPython
@@ -70,9 +70,9 @@ def_exec_lines = [line + '\n' for line in ipapp.exec_lines]
 
 
 def _init_pdb(context=3):
-    if 'context' in getargspec(Pdb.__init__)[0]:
+    try:
         p = Pdb(def_colors, context=context)
-    else:
+    except TypeError:
         p = Pdb(def_colors)
     p.rcLines += def_exec_lines
     return p

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -24,11 +24,11 @@ def import_module(possible_modules, needed_module):
             if count == 0:
                 raise
 try:
-    # IPython 5.0 and newer
+    from IPython.core.debugger import Pdb, BdbQuit_excepthook
+except ImportError:
+    # For some versions of IPython 5.x
     from IPython.terminal.debugger import TerminalPdb as Pdb
     from IPython.core.debugger import BdbQuit_excepthook
-except ImportError:
-    from IPython.core.debugger import Pdb, BdbQuit_excepthook
 
 possible_modules = ['IPython.terminal.ipapp',           # Newer IPython
                     'IPython.frontend.terminal.ipapp']  # Older IPython


### PR DESCRIPTION
Fix #113 
IPython.terminal.debugger.TerminalPdb does not receive any named args.
In new version of IPython 'context' arg can be found in parent class IPython.core.debugger.Pdb, not in IPython.terminal.debugger.TerminalPdb
