### PR TITLE
Fixes #113: set_trace ignores context arg

### DIFF
--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -70,9 +70,9 @@ def_exec_lines = [line + '\n' for line in ipapp.exec_lines]
 
 
 def _init_pdb(context=3):
-    if 'context' in getargspec(Pdb.__init__)[0]:
+    try:
         p = Pdb(def_colors, context=context)
-    else:
+    except TypeError:
         p = Pdb(def_colors)
     p.rcLines += def_exec_lines
     return p

--- a/ipdb/stdout.py
+++ b/ipdb/stdout.py
@@ -2,8 +2,8 @@ from __future__ import print_function
 import sys
 from contextlib import contextmanager
 from IPython.utils import io
-from __main__ import set_trace
-from __main__ import post_mortem
+from ipdb.__main__ import set_trace
+from ipdb.__main__ import post_mortem
 
 
 def update_stdout():


### PR DESCRIPTION
EDIT: Instead of merging this PR, I think https://github.com/gotcha/ipdb/pull/114 should be merged.  As soon as that one gets merged, we can close this one.

I believe it's better to just attempt to pass in the `context` arg rather than attempt introspection.

I'm actually curious, under what circumstance does `Pdb` not accept `context`?  Is that some old version of `IPython`?  Just wondering if we can further clean this up by removing this exception handling...

Fixes: #113.
