### PR TITLE
Command line usage consistent with pdb - Add argument commands

### DIFF
--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -183,7 +183,7 @@ def main():
         print('Error:', mainpyfile, 'does not exist')
         sys.exit(1)
 
-    del sys.argv[0]         # Hide "pdb.py" from argument list
+    sys.argv[1:] = args     # Hide "pdb.py" from argument list
 
     # Replace pdb's dir with script's dir in front of module search path.
     sys.path[0] = os.path.dirname(mainpyfile)

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -183,7 +183,7 @@ def main():
         print('Error:', mainpyfile, 'does not exist')
         sys.exit(1)
 
-    sys.argv[1:] = args     # Hide "pdb.py" from argument list
+    sys.argv = args     # Hide "pdb.py" from argument list
 
     # Replace pdb's dir with script's dir in front of module search path.
     sys.path[0] = os.path.dirname(mainpyfile)


### PR DESCRIPTION
Commands can now be passed on the command line.
e.g.
```ipdb -c "until file.py:23" file.py```
Sets a breakpoint on line 23.
Runs script until breakpoint or exception.

This is consistent with standard library module pdb.