### PR TITLE
Simplify loading IPython and getting information from it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -31,7 +31,6 @@ if shell is None:
     # This is especially important for tools that fiddle with stdout
     debugger_cls = ipapp.shell.debugger_cls
     def_colors = ipapp.shell.colors
-    def_exec_lines = [line + '\n' for line in ipapp.exec_lines]
 else:
     # Running inside IPython
     debugger_cls = shell.debugger_cls
@@ -44,14 +43,11 @@ else:
             "the configuration will not be loaded.\n\n"
         )
 
-    def_exec_lines = []
-
 def _init_pdb(context=3, commands=[]):
     try:
         p = debugger_cls(def_colors, context=context)
     except TypeError:
         p = debugger_cls(def_colors)
-    p.rcLines += def_exec_lines
     p.rcLines.extend(commands)
     return p
 

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -27,14 +27,9 @@ if shell is None:
     # Avoid output (banner, prints)
     ipapp.interact = False
     ipapp.initialize([])
-    # Let IPython decide about which debugger class to use
-    # This is especially important for tools that fiddle with stdout
-    debugger_cls = ipapp.shell.debugger_cls
-    def_colors = ipapp.shell.colors
+    shell = ipapp.shell
 else:
     # Running inside IPython
-    debugger_cls = shell.debugger_cls
-    def_colors = shell.colors
 
     # Detect if embed shell or not and display a message
     if isinstance(shell, InteractiveShellEmbed):
@@ -42,6 +37,11 @@ else:
             "\nYou are currently into an embedded ipython shell,\n"
             "the configuration will not be loaded.\n\n"
         )
+
+# Let IPython decide about which debugger class to use
+# This is especially important for tools that fiddle with stdout
+debugger_cls = shell.debugger_cls
+def_colors = shell.colors
 
 def _init_pdb(context=3, commands=[]):
     try:

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -34,7 +34,6 @@ if shell is None:
     def_exec_lines = [line + '\n' for line in ipapp.exec_lines]
 else:
     # Running inside IPython
-    shell = get_ipython()
     debugger_cls = shell.debugger_cls
     def_colors = shell.colors
 

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -12,66 +12,40 @@ from contextlib import contextmanager
 
 __version__= "0.10.3"
 
-def import_module(possible_modules, needed_module):
-    """Make it more resilient to different versions of IPython and try to
-    find a module."""
-    count = len(possible_modules)
-    for module in possible_modules:
-        try:
-            return __import__(module, fromlist=[needed_module])
-        except ImportError:
-            count -= 1
-            if count == 0:
-                raise
-try:
-    # IPython 5.0 and newer
-    from IPython.terminal.debugger import TerminalPdb as Pdb
-    from IPython.core.debugger import BdbQuit_excepthook
-    from IPython.terminal.interactiveshell import TerminalInteractiveShell
-    # Let IPython decide about which debugger class to use
-    # This is especially important for tools that fiddle with stdout
-    debugger_cls = TerminalInteractiveShell().debugger_cls
-except ImportError:
-    from IPython.core.debugger import Pdb, BdbQuit_excepthook
-    debugger_cls = Pdb
+from IPython import get_ipython
+from IPython.core.debugger import BdbQuit_excepthook
+from IPython.terminal.ipapp import TerminalIPythonApp
+from IPython.terminal.embed import InteractiveShellEmbed
 
-possible_modules = ['IPython.terminal.ipapp',           # Newer IPython
-                    'IPython.frontend.terminal.ipapp']  # Older IPython
 
-app = import_module(possible_modules, "TerminalIPythonApp")
-TerminalIPythonApp = app.TerminalIPythonApp
-
-possible_modules = ['IPython.terminal.embed',           # Newer IPython
-                    'IPython.frontend.terminal.embed']  # Older IPython
-embed = import_module(possible_modules, "InteractiveShellEmbed")
-InteractiveShellEmbed = embed.InteractiveShellEmbed
-try:
-    get_ipython
-except NameError:
+shell = get_ipython()
+if shell is None:
+    # Not inside IPython
     # Build a terminal app in order to force ipython to load the
     # configuration
     ipapp = TerminalIPythonApp()
     # Avoid output (banner, prints)
     ipapp.interact = False
     ipapp.initialize([])
+    # Let IPython decide about which debugger class to use
+    # This is especially important for tools that fiddle with stdout
+    debugger_cls = ipapp.shell.debugger_cls
     def_colors = ipapp.shell.colors
+    def_exec_lines = [line + '\n' for line in ipapp.exec_lines]
 else:
-    # If an instance of IPython is already running try to get an instance
-    # of the application. If there is no TerminalIPythonApp instanciated
-    # the instance method will create a new one without loading the config.
-    # i.e: if we are in an embed instance we do not want to load the config.
-    ipapp = TerminalIPythonApp.instance()
+    # Running inside IPython
     shell = get_ipython()
+    debugger_cls = shell.debugger_cls
     def_colors = shell.colors
 
     # Detect if embed shell or not and display a message
     if isinstance(shell, InteractiveShellEmbed):
-        shell.write_err(
+        sys.stderr.write(
             "\nYou are currently into an embedded ipython shell,\n"
             "the configuration will not be loaded.\n\n"
         )
 
-def_exec_lines = [line + '\n' for line in ipapp.exec_lines]
+    def_exec_lines = []
 
 def _init_pdb(context=3, commands=[]):
     try:

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,9 @@ setup(name='ipdb',
           'setuptools'
       ],
       extras_require={
-          ':python_version == "2.6"': ['ipython >= 0.10.2, < 2.0.0'],
-          ':python_version == "2.7"': ['ipython >= 0.10.2, < 6.0.0'],
+          ':python_version == "2.7"': ['ipython >= 5.0.0, < 6.0.0'],
           # No support for python 3.0, 3.1, 3.2.
-          ':python_version >= "3.3"': ['ipython >= 0.10.2'],
+          ':python_version >= "3.3"': ['ipython >= 5.0.0'],
       },
       entry_points={
           'console_scripts': ['%s = ipdb.__main__:main' % console_script]

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,8 @@ setup(name='ipdb',
       description="IPython-enabled pdb",
       long_description=long_description,
       classifiers=[
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
@@ -45,6 +43,7 @@ setup(name='ipdb',
       include_package_data=True,
       zip_safe=True,
       test_suite='tests',
+      python_requires=">=2.7",
       install_requires=[
           'setuptools'
       ],


### PR DESCRIPTION
This makes ipdb require IPython >=5. Version 5.0.0 came out in July 2016, about 18 months ago. It's probably possible to support older versions as well, but all the compatibility code makes it much harder to understand the code.

Closes gh-142
Closes gh-99
Closes gh-81