### PR TITLE
Avoid emitting term-title bytes

### DIFF
--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -26,7 +26,7 @@ if shell is None:
     ipapp = TerminalIPythonApp()
     # Avoid output (banner, prints)
     ipapp.interact = False
-    ipapp.initialize([])
+    ipapp.initialize(['--no-term-title'])
     shell = ipapp.shell
 else:
     # Running inside IPython


### PR DESCRIPTION
Fixes #128 

```
$ cat problem.py
from IPython.terminal.ipapp import TerminalIPythonApp

ipapp = TerminalIPythonApp()
# Avoid output (banner, prints)
ipapp.interact = False
ipapp.initialize([])
shell = ipapp.shell

$ python problem.py > flah
$ od -xa flah
0000000      5d1b    3b30    5049    7479    6f68    3a6e    7320    7365
         esc   ]   0   ;   I   P   y   t   h   o   n   :  sp   s   e   s
0000020      772f    0007
           /   w bel
0000023
```

And with the fix:
``` 
$ cat test.py
from IPython.terminal.ipapp import TerminalIPythonApp

ipapp = TerminalIPythonApp()
# Avoid output (banner, prints)
ipapp.interact = False
ipapp.initialize(['--no-term-title'])
shell = ipapp.shell

$ python test.py >flah
$ od -xa flah
```

(no output from the second octal dump)