### PR TITLE
Stop setting deprecated color_scheme argument.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,4 @@ Wilfred
 WouterVH
 zvodd
 andreagrandi
+bmw

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 -------------------
 
 - Drop support for Python 3.3.x
+- Stop deprecation warnings from being raised when IPython >= 5.1 is used.
+  Support for IPython < 5.1 has been dropped.
 
 
 0.11 (2018-02-15)

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -41,13 +41,12 @@ else:
 # Let IPython decide about which debugger class to use
 # This is especially important for tools that fiddle with stdout
 debugger_cls = shell.debugger_cls
-def_colors = shell.colors
 
 def _init_pdb(context=3, commands=[]):
     try:
-        p = debugger_cls(def_colors, context=context)
+        p = debugger_cls(context=context)
     except TypeError:
-        p = debugger_cls(def_colors)
+        p = debugger_cls()
     p.rcLines.extend(commands)
     return p
 

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,9 @@ setup(name='ipdb',
           'setuptools'
       ],
       extras_require={
-          ':python_version == "2.7"': ['ipython >= 5.0.0, < 6.0.0'],
+          ':python_version == "2.7"': ['ipython >= 5.1.0, < 6.0.0'],
           # No support for python 3.0, 3.1, 3.2.
-          ':python_version >= "3.4"': ['ipython >= 5.0.0'],
+          ':python_version >= "3.4"': ['ipython >= 5.1.0'],
       },
       entry_points={
           'console_scripts': ['%s = ipdb.__main__:main' % console_script]


### PR DESCRIPTION
Fixes #144.

The deprecation warning is particularly annoying in my development setup where warnings are treated as failures during tests.

Since IPython 5.1.0, `shell.colors` is the value used for `color_scheme` anyway. See https://github.com/ipython/ipython/blob/5.1.0/IPython/core/debugger.py#L240.

`ipdb` still supports IPython 5.0 so it may make sense to either bump that dependency to 5.1 or add additional code to keep compatibility with IPython 5.0. I'm not sure which approach you prefer.