### PR TITLE
Remove Python 3.3.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ sas23
 Wilfred
 WouterVH
 zvodd
+andreagrandi

--- a/COPYING.txt
+++ b/COPYING.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2007-2016 ipdb development team
+Copyright (c) 2007-2019 ipdb development team
 
 All rights reserved.
 

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 0.11.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Drop support for Python 3.3.x
 
 
 0.11 (2018-02-15)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(name='ipdb',
       classifiers=[
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Operating System :: MacOS :: MacOS X',
@@ -50,7 +49,7 @@ setup(name='ipdb',
       extras_require={
           ':python_version == "2.7"': ['ipython >= 5.0.0, < 6.0.0'],
           # No support for python 3.0, 3.1, 3.2.
-          ':python_version >= "3.3"': ['ipython >= 5.0.0'],
+          ':python_version >= "3.4"': ['ipython >= 5.0.0'],
       },
       entry_points={
           'console_scripts': ['%s = ipdb.__main__:main' % console_script]


### PR DESCRIPTION
Python 3.3.x reached the "end of life" status on 29th September 2017. We can/should remove the support for this version since it's only causing compatibility issues with other packages and case DeprecationWarnings (see this PR as an example of both: https://github.com/gotcha/ipdb/pull/162 )