### PR TITLE
Fix long options

### DIFF
--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -134,7 +134,7 @@ def main():
         class Restart(Exception):
             pass
     
-    opts, args = getopt.getopt(sys.argv[1:], 'hc:', ['--help', '--command='])
+    opts, args = getopt.getopt(sys.argv[1:], 'hc:', ['help', 'command='])
 
     if not args:
         print(_usage)


### PR DESCRIPTION
As per https://docs.python.org/3/library/getopt.html?highlight=getopt#getopt.getopt , the leading `--` must not be included. Currently, suppying e.g. `--help` produces `GetoptError: option --help not recognized`