### PR TITLE
Revert "Add use_2to3 keyword to setup()."

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,5 @@ setup(name='ipdb',
       },
       entry_points={
           'console_scripts': ['%s = ipdb.__main__:main' % console_script]
-      },
-      use_2to3=True,
+      }
 )


### PR DESCRIPTION
Appears to not be necessary anymore (at least no changes for py37 for
me), and prevents editable installs.

Initially done for https://github.com/gotcha/ipdb/pull/16.

This reverts commit d86c166b61aa711e6b0197c3d914031c0651ca15.