### PR TITLE
Add option to use context from env var or config file

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,10 +1,15 @@
 Changelog
 =========
 
-0.12.4 (unreleased)
+0.12.5 (unreleased)
 -------------------
 
 - Nothing changed yet.
+
+0.12.4 (2020-02-28)
+-------------------
+
+- Add option to set context via environment variable or configuration file.
 
 
 0.12.3 (2019-12-03)

--- a/README.rst
+++ b/README.rst
@@ -21,10 +21,17 @@ Example usage:
         ipdb.set_trace()
         ipdb.set_trace(context=5)  # will show five lines of code
                                    # instead of the default three lines
+                                   # or you can set it via IPDB_CONTEXT_SIZE env variable
+                                   # or setup.cfg file
         ipdb.pm()
         ipdb.run('x[0] = 3')
         result = ipdb.runcall(function, arg0, arg1, kwarg='foo')
         result = ipdb.runeval('f(1,2) - 3')
+
+It's possible to set up context using a `.ipdb` file on your home folder or `setup.cfg`
+on your project folder. You can also set your file location via env var `$IPDB_CONFIG`.
+Your environment variable has priority over the home configuration file,
+which in turn has priority over the setup config file.
 
 The post-mortem function, ``ipdb.pm()``, is equivalent to the magic function
 ``%debug``.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2012-2016 Marc Abramowitz and ipdb development team
+#
+# This file is part of ipdb.
+# Redistributable under the revised BSD license
+# https://opensource.org/licenses/BSD-3-Clause
+
+try:
+    import configparser
+except:
+    import ConfigParser as configparser
+import unittest
+import os
+import tempfile
+import shutil
+from ipdb.__main__ import get_config
+
+
+class ModifiedEnvironment(object):
+    """
+    I am a context manager that sets up environment variables for a test case.
+    """
+
+    def __init__(self, **kwargs):
+        self.prev = {}
+        self.excur = kwargs
+        for k in kwargs:
+            self.prev[k] = os.getenv(k)
+
+    def __enter__(self):
+        self.update_environment(self.excur)
+
+    def __exit__(self, type, value, traceback):
+        self.update_environment(self.prev)
+
+    def update_environment(self, d):
+        for k in d:
+            if d[k] is None:
+                if k in os.environ:
+                    del os.environ[k]
+            else:
+                os.environ[k] = d[k]
+
+
+class ConfigTest(unittest.TestCase):
+    """
+    All variations of config file parsing works as expected.
+    """
+
+    def _write_file(self, path, lines):
+        f = open(path, "w")
+        f.writelines([x + "\n" for x in lines])
+        f.close()
+
+    def setUp(self):
+        """
+        Create all temporary config files for testing
+        """
+        self.tmpd = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpd)
+        # Set CWD to known empty directory so we don't pick up some other .ipdb
+        # file from the CWD tests are actually run from.
+        save_cwd = os.getcwd()
+        self.addCleanup(os.chdir, save_cwd)
+        cwd_dir = os.path.join(self.tmpd, "cwd")
+        os.mkdir(cwd_dir)
+        os.chdir(cwd_dir)
+        # This represents the $HOME config file, and doubles for the current
+        # working directory config file if we set CWD to self.tmpd
+        self.default_filename = os.path.join(self.tmpd, ".ipdb")
+        self.default_context = 10
+        self._write_file(
+            self.default_filename,
+            [
+                "# this is a test config file for ipdb",
+                "context = {}".format(str(self.default_context)),
+            ],
+        )
+        self.env_filename = os.path.join(self.tmpd, "ipdb.env")
+        self.env_context = 20
+        self._write_file(
+            self.env_filename,
+            [
+                "# this is a test config file for ipdb",
+                "context = {}".format(str(self.env_context)),
+            ],
+        )
+        self.setup_filename = os.path.join(cwd_dir, "setup.cfg")
+        self.setup_context = 25
+        self._write_file(
+            self.setup_filename,
+            [
+                "[ipdb]",
+                "context = {}".format(str(self.setup_context)),
+            ],
+        )
+
+    def test_env_nodef_nosetup(self):
+        """
+        Setup: $IPDB_CONFIG is set, $HOME/.ipdb does not exist,
+            setup.cfg does not exist
+        Result: load $IPDB_CONFIG
+        """
+        os.unlink(self.default_filename)
+        os.remove(self.setup_filename)
+        with ModifiedEnvironment(IPDB_CONFIG=self.env_filename,
+                                 HOME=self.tmpd):
+            cfg = get_config()
+            self.assertEqual(["ipdb"], cfg.sections())
+            self.assertEqual(self.env_context, cfg.getint("ipdb", "context"))
+            self.assertRaises(configparser.NoOptionError, cfg.getboolean, "ipdb", "version")
+
+    def test_noenv_def_nosetup(self):
+        """
+        Setup: $IPDB_CONFIG unset, $HOME/.ipdb exists,
+            setup.cfg does not exist
+        Result: load $HOME/.ipdb
+        """
+        os.unlink(self.env_filename)
+        os.remove(self.setup_filename)
+        with ModifiedEnvironment(IPDB_CONFIG=None, HOME=self.tmpd):
+            cfg = get_config()
+            self.assertEqual(["ipdb"], cfg.sections())
+            self.assertEqual(self.default_context, cfg.getint("ipdb", "context"))
+            self.assertRaises(configparser.NoOptionError, cfg.get, "ipdb", "version")
+
+    def test_noenv_nodef_nosetup(self):
+        """
+        Setup: $IPDB_CONFIG unset, $HOME/.ipdb does not
+            exist, setup.cfg does not exist
+        Result: load nothing
+        """
+        os.unlink(self.env_filename)
+        os.unlink(self.default_filename)
+        os.remove(self.setup_filename)
+        with ModifiedEnvironment(IPDB_CONFIG=None, HOME=self.tmpd):
+            cfg = get_config()
+            self.assertEqual([], cfg.sections())
+
+    def test_env_cwd(self):
+        """
+        Setup: $IPDB_CONFIG is set, .ipdb in local dir,
+            setup.cfg does not exist
+        Result: load .ipdb
+        """
+        os.chdir(self.tmpd)  # setUp is already set to restore us to our pre-testing cwd
+        os.remove(self.setup_filename)
+        with ModifiedEnvironment(IPDB_CONFIG=self.env_filename,
+                                 HOME=self.tmpd):
+            cfg = get_config()
+            self.assertEqual(["ipdb"], cfg.sections())
+            self.assertEqual(self.env_context, cfg.getint("ipdb", "context"))
+            self.assertRaises(configparser.NoOptionError, cfg.get, "ipdb", "version")
+
+    def test_env_def_nosetup(self):
+        """
+        Setup: $IPDB_CONFIG is set, $HOME/.ipdb exists,
+            setup.cfg does not exist
+        Result: load $IPDB_CONFIG
+        """
+        os.remove(self.setup_filename)
+        with ModifiedEnvironment(IPDB_CONFIG=self.env_filename,
+                                 HOME=self.tmpd):
+            cfg = get_config()
+            self.assertEqual(["ipdb"], cfg.sections())
+            self.assertEqual(self.env_context, cfg.getint("ipdb", "context"))
+            self.assertRaises(configparser.NoOptionError, cfg.get, "ipdb", "version")
+
+    def test_noenv_def_setup(self):
+        """
+        Setup: $IPDB_CONFIG unset, $HOME/.ipdb exists,
+            setup.cfg exists
+        Result: load $HOME/.ipdb
+        """
+        os.unlink(self.env_filename)
+        with ModifiedEnvironment(IPDB_CONFIG=None, HOME=self.tmpd):
+            cfg = get_config()
+            self.assertEqual(["ipdb"], cfg.sections())
+            self.assertEqual(self.default_context, cfg.getint("ipdb", "context"))
+            self.assertRaises(configparser.NoOptionError, cfg.getboolean, "ipdb", "version")
+
+    def test_noenv_nodef_setup(self):
+        """
+        Setup: $IPDB_CONFIG unset, $HOME/.ipdb does not exist,
+            setup.cfg exists
+        Result: load setup
+        """
+        os.unlink(self.env_filename)
+        os.unlink(self.default_filename)
+        with ModifiedEnvironment(IPDB_CONFIG=None, HOME=self.tmpd):
+            cfg = get_config()
+            self.assertEqual(["ipdb"], cfg.sections())
+            self.assertEqual(self.setup_context, cfg.getint("ipdb", "context"))
+            self.assertRaises(configparser.NoOptionError, cfg.get, "ipdb", "version")
+
+    def test_env_def_setup(self):
+        """
+        Setup: $IPDB_CONFIG is set, $HOME/.ipdb exists,
+            setup.cfg exists
+        Result: load $IPDB_CONFIG
+        """
+        with ModifiedEnvironment(IPDB_CONFIG=self.env_filename,
+                                 HOME=self.tmpd):
+            cfg = get_config()
+            self.assertEqual(["ipdb"], cfg.sections())
+            self.assertEqual(self.env_context, cfg.getint("ipdb", "context"))
+            self.assertRaises(configparser.NoOptionError, cfg.get, "ipdb", "version")
+
+    def test_env_nodef_setup(self):
+        """
+        Setup: $IPDB_CONFIG is set, $HOME/.ipdb does not
+            exist, setup.cfg exists
+        Result: load $IPDB_CONFIG
+        """
+        os.unlink(self.default_filename)
+        with ModifiedEnvironment(IPDB_CONFIG=self.env_filename,
+                                 HOME=self.tmpd):
+            cfg = get_config()
+            self.assertEqual(["ipdb"], cfg.sections())
+            self.assertEqual(self.env_context, cfg.getint("ipdb", "context"))
+            self.assertRaises(configparser.NoOptionError, cfg.getboolean, "ipdb", "version")
+
+    def test_noenv_def_setup(self):
+        """
+        Setup: $IPDB_CONFIG unset, $HOME/.ipdb exists,
+            setup.cfg exists
+        Result: load $HOME/.ipdb
+        """
+        os.unlink(self.env_filename)
+        with ModifiedEnvironment(IPDB_CONFIG=None, HOME=self.tmpd):
+            cfg = get_config()
+            self.assertEqual(["ipdb"], cfg.sections())
+            self.assertEqual(self.default_context, cfg.getint("ipdb", "context"))
+            self.assertRaises(configparser.NoOptionError, cfg.get, "ipdb", "version")


### PR DESCRIPTION
Add option to retrieve context from environment variable `IPDB_CONTEXT_SIZE` or from `setup.cfg` file.