### PR TITLE
Add -m option

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 0.13.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add '-m' option
+  [mrmino]
 
 
 0.13.2 (2020-03-03)

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -228,6 +228,9 @@ and in the current directory, if they exist.  Commands supplied with
 To let the script run until an exception occurs, use "-c continue".
 To let the script run up to a given line X in the debugged file, use
 "-c 'until X'"
+
+Option -m is available only in Python 3.7 and later.
+
 ipdb version %s.""" % __version__
 
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ setup(name='ipdb',
           # No support for python 3.0, 3.1, 3.2.
           ':python_version >= "3.4"': ['ipython >= 5.1.0'],
       },
+      tests_require=[
+          'mock'
+      ],
       entry_points={
           'console_scripts': ['%s = ipdb.__main__:main' % console_script]
       }

--- a/tests/test_opts.py
+++ b/tests/test_opts.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2012-2016 Marc Abramowitz and ipdb development team
+#
+# This file is part of ipdb.
+# Redistributable under the revised BSD license
+# https://opensource.org/licenses/BSD-3-Clause
+
+import unittest
+from unittest.mock import patch
+from getopt import GetoptError
+from ipdb.__main__ import main
+
+
+@patch('ipdb.__main__.debugger_cls')
+class OptsTest(unittest.TestCase):
+    def set_argv(self, *argv):
+        argv_patch = patch('ipdb.__main__.sys.argv', argv)
+        argv_patch.start()
+        self.addCleanup(argv_patch.stop)
+
+    @patch('ipdb.__main__.sys.version_info', (3, 7))
+    def test_debug_module_script(self, debugger_cls):
+        module_name = 'my_buggy_module'
+        self.set_argv('ipdb', '-m', module_name)
+
+        main()
+
+        debugger = debugger_cls.return_value
+        debugger._runmodule.assert_called_once_with(module_name)
+
+    @patch('ipdb.__main__.os.path.exists')
+    def test_debug_script(self, exists, debugger_cls):
+        script_name = 'my_buggy_script'
+        self.set_argv('ipdb', script_name)
+
+        main()
+
+        debugger = debugger_cls.return_value
+        debugger._runscript.assert_called_once_with(script_name)
+
+    def test_option_m_fallback_on_py36(self, debugger_cls):
+        self.set_argv('ipdb', '-m', 'my.module')
+        with patch('ipdb.__main__.sys.version_info', (3, 6)):
+            with self.assertRaises(GetoptError):
+                main()
+
+        with patch('ipdb.__main__.sys.version_info', (3, 7)):
+            self.set_argv('ipdb', '-m', 'my.module')
+            try:
+                main()
+            except GetoptError:
+                self.fail("GetoptError raised unexpectedly.")

--- a/tests/test_opts.py
+++ b/tests/test_opts.py
@@ -5,7 +5,11 @@
 # https://opensource.org/licenses/BSD-3-Clause
 
 import unittest
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
 from getopt import GetoptError
 from ipdb.__main__ import main
 


### PR DESCRIPTION
This adds a `-m` option that was introduced in Python 3.7 pdb. It is
implemented in a backward-compatible way: if the version of python is
lower than 3.7, the script will fallback to shortopts without -m.

See #192.

- Added `-m` option
- Added `test/test_opts.py` for coverage
- Added `mock` to `tests_require` in `setup.py`, so that tests work with Python 2.7.