### PR TITLE
Add condition variable to set_trace

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 0.13.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add condition argument to set_trace
 
 
 0.13.2 (2020-03-03)
@@ -24,7 +24,7 @@ Changelog
 0.13.0 (2020-02-28)
 -------------------
 
-- Add option to set context via environment variable or configuration file.
+- Add option to set context via environment variable or configuration file
   [alexandrebarbaruiva]
 
 

--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,13 @@ Development
 
 Pull requests should take care of updating the changelog ``HISTORY.txt``.
 
+Manual testing
+++++++++++++++
+
+To test your changes, make use of ``manual_test.py``. Create a virtual environment,
+install IPython and run ``python manual_test.py`` and check if your changes are in effect.
+If possible, create automated tests for better behaviour control.
+
 Third-party support
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,7 @@ Example usage:
         result = ipdb.runcall(function, arg0, arg1, kwarg='foo')
         result = ipdb.runeval('f(1,2) - 3')
 
+
 Arguments for `set_trace`
 +++++++++++++++++++++++++
 
@@ -45,15 +46,19 @@ which in turn has priority over the setup config file. Currently, only context s
 is available.
 
 A valid setup.cfg is as follows
-```
-[ipdb]
-context=5
-```
+
+::
+
+        [ipdb]
+        context=5
+
 
 A valid .ipdb is as follows
-```
-context=5
-```
+
+::
+
+        context=5
+
 
 The post-mortem function, ``ipdb.pm()``, is equivalent to the magic function
 ``%debug``.

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,13 @@ Example usage:
         result = ipdb.runcall(function, arg0, arg1, kwarg='foo')
         result = ipdb.runeval('f(1,2) - 3')
 
+Arguments for `set_trace`
++++++++++++++++++++++++++
+
+The `set_trace` function accepts `context` which will show as many lines of code as defined,
+and `cond`, which accepts boolean values (such as `abc == 17`) and will start ipdb's
+interface whenever `cond` equals to `True`.
+
 Using configuration file
 ++++++++++++++++++++++++
 

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -65,17 +65,18 @@ def wrap_sys_excepthook():
 
 
 def set_trace(frame=None, context=None, cond=True):
-    if cond:
-        wrap_sys_excepthook()
-        if not context:
-            context = os.environ.get(
-                "IPDB_CONTEXT_SIZE", get_context_from_config()
-            )
-        if frame is None:
-            frame = sys._getframe().f_back
-        p = _init_pdb(context).set_trace(frame)
-        if p and hasattr(p, 'shell'):
-            p.shell.restore_sys_module_state()
+    if not cond:
+        return
+    wrap_sys_excepthook()
+    if not context:
+        context = os.environ.get(
+            "IPDB_CONTEXT_SIZE", get_context_from_config()
+        )
+    if frame is None:
+        frame = sys._getframe().f_back
+    p = _init_pdb(context).set_trace(frame)
+    if p and hasattr(p, 'shell'):
+        p.shell.restore_sys_module_state()
 
 
 def get_context_from_config():

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -64,17 +64,18 @@ def wrap_sys_excepthook():
         sys.excepthook = BdbQuit_excepthook
 
 
-def set_trace(frame=None, context=None):
-    wrap_sys_excepthook()
-    if not context:
-        context = os.environ.get(
-            "IPDB_CONTEXT_SIZE", get_context_from_config()
-        )
-    if frame is None:
-        frame = sys._getframe().f_back
-    p = _init_pdb(context).set_trace(frame)
-    if p and hasattr(p, 'shell'):
-        p.shell.restore_sys_module_state()
+def set_trace(frame=None, context=None, cond=True):
+    if cond:
+        wrap_sys_excepthook()
+        if not context:
+            context = os.environ.get(
+                "IPDB_CONTEXT_SIZE", get_context_from_config()
+            )
+        if frame is None:
+            frame = sys._getframe().f_back
+        p = _init_pdb(context).set_trace(frame)
+        if p and hasattr(p, 'shell'):
+            p.shell.restore_sys_module_state()
 
 
 def get_context_from_config():


### PR DESCRIPTION
Add condition variable to set_trace to show console only when ``cond=True``.

This way, instead of doing
```
for abc in range(1, 100):
    if abc == 13:
        import ipdb; ipdb.set_trace()
```
You do this
```
for abc in range(1, 100):
    import ipdb; ipdb.set_trace(cond=(abc==13))
```