### PR TITLE
use default context for all debug tools

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 0.13.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Allow runcall, runeval to also use set context value
+  [meowser]
 
 
 0.13.2 (2020-03-03)

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -47,7 +47,9 @@ else:
 debugger_cls = shell.debugger_cls
 
 
-def _init_pdb(context=3, commands=[]):
+def _init_pdb(context=None, commands=[]):
+    if context is None:
+        context = os.getenv("IPDB_CONTEXT_SIZE", get_context_from_config())
     try:
         p = debugger_cls(context=context)
     except TypeError:
@@ -66,10 +68,6 @@ def wrap_sys_excepthook():
 
 def set_trace(frame=None, context=None):
     wrap_sys_excepthook()
-    if not context:
-        context = os.environ.get(
-            "IPDB_CONTEXT_SIZE", get_context_from_config()
-        )
     if frame is None:
         frame = sys._getframe().f_back
     p = _init_pdb(context).set_trace(frame)


### PR DESCRIPTION
 - moved context config call to _init_pdb
 - removed context default of 3 from _init_pdb (get_context_from_config
   will default to 3 if it cannot find a set context)