### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+   - amd64
+   - ppc64le
 language: python
 python:
   - "2.7"
@@ -9,6 +12,10 @@ python:
   - "3.8-dev"
   - "nightly"
   - "pypy"
+matrix:
+   exclude:
+      - python: "pypy"
+        arch: ppc64le
 before_install:
   # Update pip and setuptools to the latest.
   - pip install --upgrade pip setuptools


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/ipdb/builds/191024301 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!