### PR TITLE
Fix ipython version for python 3.6

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ steinnes
 Wilfred
 WouterVH
 zvodd
+d1618033

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,11 @@ Changelog
 0.13.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- For users using python 3.4, install 6.0.0 <= IPython < 7.0.0,
+  for users using python 3.5, install 7.0.0 <= IPython < 7.10.0,
+  for users using python 3.6, install 7.10.0 <= IPython < 7.17.0,
+  for users using python>3.6, install IPython >= 7.17.0.
+  [d1618033]
 
 
 0.13.4 (2020-10-01)

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,10 @@ setup(name='ipdb',
       extras_require={
           ':python_version == "2.7"': ['ipython >= 5.1.0, < 6.0.0'],
           # No support for python 3.0, 3.1, 3.2.
-          ':python_version >= "3.4"': ['ipython >= 5.1.0'],
+          ':python_version == "3.4"': ['ipython >= 6.0.0, < 7.0.0'],
+          ':python_version == "3.5"': ['ipython >= 7.0.0, < 7.10.0'],
+          ':python_version == "3.6"': ['ipython >= 7.10.0, < 7.17.0'],
+          ':python_version > "3.6"': ['ipython >= 7.17.0'],
       },
       tests_require=[
           'mock'


### PR DESCRIPTION
See [here](https://github.com/ipython/ipython/blob/master/setup.py#L44):
```
IPython 7.17+ supports Python 3.7 and above, following NEP 29.
When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
Python 3.3 and 3.4 were supported up to IPython 6.x.
Python 3.5 was supported with IPython 7.0 to 7.9.
Python 3.6 was supported with IPython up to 7.16.
```
