### PR TITLE
setup.py: Do not require mock in Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(name='ipdb',
           ':python_version > "3.6"': ['ipython >= 7.17.0'],
       },
       tests_require=[
-          'mock'
+          'mock; python_version<"3"'
       ],
       entry_points={
           'console_scripts': ['%s = ipdb.__main__:main' % console_script]


### PR DESCRIPTION
The code will always use 'unittest.mock' in Python 3, so stop pulling
the 'mock' package unnecessarily.