### PR TITLE
Support launch_ipdb_on_exception as a function decorator

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 0.13.8 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add the convenience function ``iex()``.
+  [alanbernstein]
 
 
 0.13.7 (2021-03-16)

--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,16 @@ You can also enclose code with the ``with`` statement to launch ipdb if an excep
    Adding a context manager implies dropping Python 2.4 support.
    Use ``ipdb==0.6`` with 2.4.
 
+Or you can use ``iex`` as a function decorator to launch ipdb if an exception is raised:
+
+.. code-block:: python
+
+        from ipdb import iex
+
+        @iex
+        def main():
+            [...]
+
 .. warning::
    Using ``from future import print_function`` for Python 3 compat implies dropping Python 2.5 support.
    Use ``ipdb<=0.8`` with 2.5.

--- a/ipdb/__init__.py
+++ b/ipdb/__init__.py
@@ -4,7 +4,7 @@
 # Redistributable under the revised BSD license
 # https://opensource.org/licenses/BSD-3-Clause
 
-from ipdb.__main__ import set_trace, post_mortem, pm, run             # noqa
+from ipdb.__main__ import set_trace, post_mortem, pm, run, iex        # noqa
 from ipdb.__main__ import runcall, runeval, launch_ipdb_on_exception  # noqa
 
 from ipdb.stdout import sset_trace, spost_mortem, spm                 # noqa

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -228,6 +228,29 @@ def launch_ipdb_on_exception():
         pass
 
 
+class Decontext(object):
+    """
+    Makes a context manager also act as decorator.
+    """
+    def __init__(self, context_manager):
+        self._cm = context_manager
+
+    def __enter__(self):
+        return self._cm.__enter__()
+
+    def __exit__(self, *args, **kwds):
+        return self._cm.__exit__(*args, **kwds)
+
+    def __call__(self, func):
+        def wrapper(*args, **kwds):
+            with self:
+                return func(*args, **kwds)
+        return wrapper
+
+
+iex = Decontext(launch_ipdb_on_exception())
+
+
 _usage = """\
 usage: python -m ipdb [-m] [-c command] ... pyfile [arg] ...
 

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 import os
 import sys
 
-from contextlib import contextmanager
+from decorator import contextmanager
 
 __version__ = '0.13.8.dev0'
 
@@ -228,27 +228,8 @@ def launch_ipdb_on_exception():
         pass
 
 
-class Decontext(object):
-    """
-    Makes a context manager also act as decorator.
-    """
-    def __init__(self, context_manager):
-        self._cm = context_manager
-
-    def __enter__(self):
-        return self._cm.__enter__()
-
-    def __exit__(self, *args, **kwds):
-        return self._cm.__exit__(*args, **kwds)
-
-    def __call__(self, func):
-        def wrapper(*args, **kwds):
-            with self:
-                return func(*args, **kwds)
-        return wrapper
-
-
-iex = Decontext(launch_ipdb_on_exception())
+# iex is a concise alias
+iex = launch_ipdb_on_exception()
 
 
 _usage = """\

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(name='ipdb',
               'toml >= 0.10.2'
           ],
           # No support for python 3.0, 3.1, 3.2.
-          ':python_version == "3.4"': ['ipython >= 6.0.0, < 7.0.0', 'toml >= 0.10.2'],
+          ':python_version == "3.4"': ['ipython >= 6.0.0, < 7.0.0', 'toml >= 0.10.2', 'decorator < 5.0.0'],
           ':python_version == "3.5"': ['ipython >= 7.0.0, < 7.10.0', 'toml >= 0.10.2'],
           ':python_version == "3.6"': ['ipython >= 7.10.0, < 7.17.0', 'toml >= 0.10.2'],
           ':python_version > "3.6"': ['ipython >= 7.17.0', 'toml >= 0.10.2'],

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(name='ipdb',
               'toml >= 0.10.2'
           ],
           # No support for python 3.0, 3.1, 3.2.
+          # decorator is also a dependency of Ipython.
           ':python_version == "3.4"': ['ipython >= 6.0.0, < 7.0.0', 'toml >= 0.10.2', 'decorator < 5.0.0'],
           ':python_version == "3.5"': ['ipython >= 7.0.0, < 7.10.0', 'toml >= 0.10.2'],
           ':python_version == "3.6"': ['ipython >= 7.10.0, < 7.17.0', 'toml >= 0.10.2'],

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -10,10 +10,11 @@ import unittest
 class ImportTest(unittest.TestCase):
 
     def test_import(self):
-        from ipdb import set_trace, post_mortem, pm, run, runcall, runeval
+        from ipdb import set_trace, post_mortem, pm, iex, run, runcall, runeval
         set_trace  # please pyflakes
         post_mortem  # please pyflakes
         pm  # please pyflakes
+        iex # please pyflakes
         run  # please pyflakes
         runcall  # please pyflakes
         runeval  # please pyflakes


### PR DESCRIPTION
Fixes #215.

I chose `iex` (**i**pdb **ex**ception) instead of my previous conflicting `pm`. It's a concise name because that's how I like my debugging tools (and I assume the existing `pm` was also chosen for conciseness). If that's not acceptable here, I think I'll instead try to figure out a good way to make `launch_ipdb_on_exception` itself a function decorator, so it can be imported as `from ipdb import launch_ipdb_on_exception as iex`.