### PR TITLE
Carefully tests if `pyproject.toml` contains a `tool` section

### DIFF
--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -178,7 +178,7 @@ def get_config():
             elif filepath.endswith('pyproject.toml'):
                 import toml
                 toml_file = toml.load(filepath)
-                if "ipdb" in toml_file["tool"]:
+                if "ipdb" in toml_file.get("tool"):
                     if not parser.has_section("ipdb"):
                         parser.add_section("ipdb")
                     for key, value in toml_file["tool"]["ipdb"].items():


### PR DESCRIPTION
This commit fixes #227.