### PR TITLE
Remove ppc64le tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 arch:
    - amd64
-   - ppc64le
 language: python
 python:
   - "2.7"
@@ -12,10 +11,6 @@ python:
   - "3.10-dev"
   - "nightly"
   - "pypy"
-matrix:
-   exclude:
-      - python: "pypy"
-        arch: ppc64le
 before_install:
   # Update pip and setuptools to the latest.
   - pip install --upgrade pip setuptools


### PR DESCRIPTION
Reverts #208. This was a marketing campaign via PR by IBM. This project is pure python so does not need testing on alternative CPU architectures. And no one reported any problems with ppc64le, because basically no one uses it.