### PR TITLE
Update dependencies

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -5,7 +5,6 @@ Changelog
 --------------------
 
 - Based on OSV:PYSEC-2022-12 change ipython dependencies,
-  for users using python 2.7, install 5.11 <= IPython < 6.0.0,
   for users using python 3.6, install 7.16.3 <= IPython < 7.17.0,
   for users using python>3.6, install IPython >= 7.31.1.
 

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 0.13.10 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Based on OSV:PYSEC-2022-12 change ipython dependencies,
+  for users using python 2.7, install 5.11 <= IPython < 6.0.0,
+  for users using python 3.6, install 7.16.3 <= IPython < 7.17.0,
+  for users using python>3.6, install IPython >= 7.31.1.
 
 
 0.13.9 (2021-06-02)

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(name='ipdb',
           'setuptools',
       ],
       extras_require={
-          ':python_version == "2.7"': ['ipython >= 5.11.0, < 6.0.0', 'toml >= 0.10.2', 'decorator < 5.0.0'],
+          ':python_version == "2.7"': ['ipython >= 5.1.0, < 6.0.0', 'toml >= 0.10.2', 'decorator < 5.0.0'],
           # No support for python 3.0, 3.1, 3.2.
           # FTR, `decorator` is also a dependency of Ipython.
           ':python_version == "3.4"': ['ipython >= 6.0.0, < 7.0.0', 'toml >= 0.10.2', 'decorator < 5.0.0'],

--- a/setup.py
+++ b/setup.py
@@ -59,13 +59,13 @@ setup(name='ipdb',
           'setuptools',
       ],
       extras_require={
-          ':python_version == "2.7"': ['ipython >= 5.1.0, < 6.0.0', 'toml >= 0.10.2', 'decorator < 5.0.0'],
+          ':python_version == "2.7"': ['ipython >= 5.11.0, < 6.0.0', 'toml >= 0.10.2', 'decorator < 5.0.0'],
           # No support for python 3.0, 3.1, 3.2.
           # FTR, `decorator` is also a dependency of Ipython.
           ':python_version == "3.4"': ['ipython >= 6.0.0, < 7.0.0', 'toml >= 0.10.2', 'decorator < 5.0.0'],
           ':python_version == "3.5"': ['ipython >= 7.0.0, < 7.10.0', 'toml >= 0.10.2', 'decorator'],
-          ':python_version == "3.6"': ['ipython >= 7.10.0, < 7.17.0', 'toml >= 0.10.2', 'decorator'],
-          ':python_version > "3.6"': ['ipython >= 7.17.0', 'toml >= 0.10.2', 'decorator'],
+          ':python_version == "3.6"': ['ipython >= 7.16.3, < 7.17.0', 'toml >= 0.10.2', 'decorator'],
+          ':python_version > "3.6"': ['ipython >= 7.31.1', 'toml >= 0.10.2', 'decorator'],
       },
       tests_require=[
           'mock; python_version<"3"'


### PR DESCRIPTION
Patches out vulnerable versions of IPython from CVE-2022-21699.

See more info:

- https://github.com/ipython/ipython/security/advisories/GHSA-pq7m-3gw7-gq5x
- https://ipython.readthedocs.io/en/stable/whatsnew/version8.html#ipython-8-0-1-cve-2022-21699

Also see commit, I am unsure this will work 5.11 will work as it's source only.