### PR TITLE
Use context manager for toml file open.

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 0.13.12 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Use context manager for opening toml config
+  [andrewzwicky]
 
 
 0.13.11 (2022-12-13)

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -186,12 +186,13 @@ def get_config():
                     except ImportError:
                         import toml as tomllib
                         file_mode = "r"
-                toml_file = tomllib.load(open(filepath, file_mode))
-                if "tool" in toml_file and "ipdb" in toml_file["tool"]:
-                    if not parser.has_section("ipdb"):
-                        parser.add_section("ipdb")
-                    for key, value in toml_file["tool"]["ipdb"].items():
-                        parser.set("ipdb", key, str(value))
+                with open(filepath, file_mode) as f:
+                    toml_file = tomllib.load(f)
+                    if "tool" in toml_file and "ipdb" in toml_file["tool"]:
+                        if not parser.has_section("ipdb"):
+                            parser.add_section("ipdb")
+                        for key, value in toml_file["tool"]["ipdb"].items():
+                            parser.set("ipdb", key, str(value))
             else:
                 read_func(ConfigFile(filepath))
     return parser


### PR DESCRIPTION
Use context manager for file opening, will close file properly once work is finished.

I found this poking around and running the unit tests and seeing lots of these warnings:
```
/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/tomllib/_parser.py:66: ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/tmp0agdoy89/cwd/pyproject.toml'>
  return loads(s, parse_float=parse_float)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```