### PR TITLE
fix python 3.11+ and update tests

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 0.13.12 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Modify tests to test 3.11 separately from earlier python versions.
+  [andrewzwicky]
 
 
 0.13.11 (2022-12-13)

--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -309,7 +309,7 @@ def main():
     while 1:
         try:
             import pdb as stdlib_pdb
-            if hasattr(stdlib_pdb, "_run"):
+            if hasattr(stdlib_pdb.Pdb, "_run"):
                 # Looks like Pdb from Python 3.11+
                 if run_as_module:
                     pdb._run(stdlib_pdb._ModuleTarget(mainpyfile))

--- a/tests/test_opts.py
+++ b/tests/test_opts.py
@@ -4,7 +4,10 @@
 # Redistributable under the revised BSD license
 # https://opensource.org/licenses/BSD-3-Clause
 
+import sys
 import unittest
+import os
+
 try:
     from unittest.mock import patch
 except ImportError:
@@ -21,6 +24,10 @@ class OptsTest(unittest.TestCase):
         argv_patch.start()
         self.addCleanup(argv_patch.stop)
 
+    @unittest.skipIf(
+        sys.version_info[0] == 3 and sys.version_info[1] >= 11,
+        ">3.11 requires different test",
+    )
     @patch('ipdb.__main__.sys.version_info', (3, 7))
     def test_debug_module_script(self, get_debugger_cls):
         module_name = 'my_buggy_module'
@@ -31,6 +38,10 @@ class OptsTest(unittest.TestCase):
         debugger = get_debugger_cls.return_value.return_value
         debugger._runmodule.assert_called_once_with(module_name)
 
+    @unittest.skipIf(
+        sys.version_info[0] == 3 and sys.version_info[1] >= 11,
+        ">3.11 requires different test",
+    )
     @patch('ipdb.__main__.os.path.exists')
     def test_debug_script(self, exists, get_debugger_cls):
         script_name = 'my_buggy_script'
@@ -40,6 +51,33 @@ class OptsTest(unittest.TestCase):
 
         debugger = get_debugger_cls.return_value.return_value
         debugger._runscript.assert_called_once_with(script_name)
+
+    @unittest.skipIf(
+        sys.version_info[0] != 3 or sys.version_info[1] < 11,
+        "<3.11 requires different test",
+    )
+    def test_debug_module_script_3_11(self, get_debugger_cls):
+        module_name = 'my_buggy_module_3_11'
+        self.set_argv('ipdb', '-m', module_name)
+
+        main()
+
+        debugger = get_debugger_cls.return_value.return_value
+        debugger._run.assert_called_once_with(module_name)
+
+    @unittest.skipIf(
+        sys.version_info[0] != 3 or sys.version_info[1] < 11,
+        "<3.11 requires different test",
+    )
+    @patch('ipdb.__main__.os.path.exists')
+    def test_debug_script_3_11(self, exists, get_debugger_cls):
+        script_name = 'my_buggy_script_3_11'
+        self.set_argv('ipdb', script_name)
+
+        main()
+
+        debugger = get_debugger_cls.return_value.return_value
+        debugger._run.assert_called_once_with(os.path.join(os.getcwd(), script_name))
 
     def test_option_m_fallback_on_py36(self, get_debugger_cls):
         self.set_argv('ipdb', '-m', 'my.module')


### PR DESCRIPTION
The fix for python 3.11+ to use `_run` instead was not working for me, but the tests were also still checking for the old code path as well.  Comments welcome, not sure if you want this in a different style or format or whatever.

I tested a local install and it fixed my issues I was having.  Before this fix, I was getting the following error on 3.11

```
Traceback (most recent call last):
  File "C:\Users\Andrew\AppData\Local\Programs\Python\Python311\Lib\site-packages\ipdb\__main__.py", line 322, in main
    pdb._runscript(mainpyfile)
    ^^^^^^^^^^^^^^
AttributeError: 'TerminalPdb' object has no attribute '_runscript'
```