### PR TITLE
feat: support executables passed to ipdb3

### DIFF
--- a/ipdb/__main__.py
+++ b/ipdb/__main__.py
@@ -12,6 +12,7 @@ from decorator import contextmanager
 
 __version__ = "0.13.14.dev0"
 
+from shutil import which
 from IPython import get_ipython
 from IPython.core.debugger import BdbQuit_excepthook
 from IPython.terminal.ipapp import TerminalIPythonApp
@@ -300,6 +301,11 @@ def main():
         sys.exit(2)
 
     mainpyfile = args[0]  # Get script filename
+
+    # a executable command in $PATH may be passed
+    if not os.path.exists(mainpyfile):
+        mainpyfile = which(mainpyfile)
+
     if not run_as_module and not os.path.exists(mainpyfile):
         print("Error:", mainpyfile, "does not exist")
         sys.exit(1)


### PR DESCRIPTION
For instance, if your project has a script section a bin/ entry in your venv
will be generated. It's helpful to be able to pass the command reference to
ipdb for debugging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The debugger now supports resolving executables from your system PATH, allowing you to launch sessions by passing executable names directly without specifying full file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->