### PR TITLE
update readme for autocompletion when using ipdb with pytest 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -196,11 +196,11 @@ instead of ``pdb``. (It does not depend on ``ipdb`` anymore).
 pytest
 +++++++
 pytest_ supports a ``--pdb`` option which can run ``ipdb`` /
-``IPython.terminal.debugger:Pdb`` on ``Exception`` and ``breakpoint()``:
+``IPython.terminal.debugger:TerminalPdb`` on ``Exception`` and ``breakpoint()``:
 
 .. code:: bash
 
-    pytest --pdb --pdbcls=IPython.terminal.debugger:Pdb -v ./test_example.py
+    pytest --pdb --pdbcls=IPython.terminal.debugger:TerminalPdb -v ./test_example.py
 
 You don't need to specify ``--pdbcls`` for every ``pytest`` invocation 
 if you add ``addopts`` to ``pytest.ini`` or ``pyproject.toml``.
@@ -210,14 +210,14 @@ if you add ``addopts`` to ``pytest.ini`` or ``pyproject.toml``.
 .. code:: bash
 
   [tool.pytest.ini_options]
-  addopts = "--pdbcls=IPython.terminal.debugger:Pdb"
+  addopts = "--pdbcls=IPython.terminal.debugger:TerminalPdb"
 
 ``pyproject.toml``:
 
 .. code:: yml
 
   [tool.pytest.ini_options]
-  addopts = "--pdbcls=IPython.terminal.debugger:Pdb"
+  addopts = "--pdbcls=IPython.terminal.debugger:TerminalPdb"
 
 
 .. _pytest: https://pypi.python.org/pypi/pytest


### PR DESCRIPTION
I was having trouble with autocomplete using just Pdb.

Based on [this issue](https://github.com/pytest-dev/pytest/issues/4008), changing to TerminalPdb fixed the problems. Probably best to update the readme to avoid other users having problems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pytest configuration examples and documentation snippets to reflect the correct debugger class references for debugging integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->